### PR TITLE
chore: set package-manager-strict to false

### DIFF
--- a/.changeset/rude-points-push.md
+++ b/.changeset/rude-points-push.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': patch
+---
+
+Make package manager not strict

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false


### PR DESCRIPTION
### What does it do?

set package-manager-strict to false

### Why is it needed?

it was annoying to force a specific version, so this way we just warn that you're not using the project version

### How to test it?

use a version other than pnpm 9.1.0 and it works with a warning now

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
