### PR TITLE
chore: use rc versions instead of beta

### DIFF
--- a/.changeset/afraid-flies-enjoy.md
+++ b/.changeset/afraid-flies-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': patch
+---
+
+Use rc versions instead of beta

--- a/src/cli/commands/plugin/init/action.ts
+++ b/src/cli/commands/plugin/init/action.ts
@@ -14,7 +14,7 @@ import type { InitOptions, TemplateFile } from '@strapi/pack-up';
 type ActionOptions = Pick<InitOptions, 'silent' | 'debug'>;
 
 // TODO: remove these when release versions are available
-const USE_BETA_VERSIONS: string[] = [
+const USE_RC_VERSIONS: string[] = [
   '@strapi/design-system',
   '@strapi/icons',
   '@strapi/strapi',
@@ -537,7 +537,7 @@ const resolveLatestVerisonOfDeps = async (
 
   for (const [name, version] of Object.entries(deps)) {
     try {
-      const range = USE_BETA_VERSIONS.includes(name) ? 'beta' : version;
+      const range = USE_RC_VERSIONS.includes(name) ? 'rc' : version;
       const latestVersion = await getLatestVersion(name, { range });
       latestDeps[name] = latestVersion ? `^${latestVersion}` : '*';
     } catch (err) {


### PR DESCRIPTION
### What does it do?

Look for 'rc' versions from npm instead of 'beta'

### Why is it needed?

We've moved from beta to rc for strapi/strapi and strapi/design-system

### How to test it?

generated plugins should now reference rc versions in package.json

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
