### PR TITLE
fix: @strapi/design-system does not provide an export named 'Page'

### DIFF
--- a/src/cli/commands/plugin/init/files/admin.ts
+++ b/src/cli/commands/plugin/init/files/admin.ts
@@ -11,7 +11,7 @@ export { PluginIcon };
 `;
 
 const APP_CODE = outdent`
-import { Page } from '@strapi/design-system';
+import { Page } from '@strapi/strapi/admin';
 import { Routes, Route } from 'react-router-dom';
 
 import { HomePage } from './HomePage';


### PR DESCRIPTION
### What does it do?

This change modifies the import statement to import `Page` from  `@strapi/strapi/admin` module.

Before:

```
import { Page } from '@strapi/design-system';
```

After:
```
import { Page } from '@strapi/strapi/admin';
```

### Why is it needed?

When run the Strapi project and access the plugin created by `@sdk/plugins` via the path `/admin/plugins/<plugin_name>`, I receive an error: 

```
SyntaxError: The requested module '/node_modules/.strapi/vite/deps/@strapi_design-system.js?v=55925766' does not provide an export named 'Page'
```
### How to test it?

- Create the plugin: Run the` ./bin/strapi-plugin.js` using the `init` command.
- Link the plugin to Strapi project.
- Run strapi project and access the plugin at path `/admin/plugins/<plugin_name>`.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request