### PR TITLE
feat: in Strapi project, init creates plugin in plugin path and logs config info

### DIFF
--- a/.changeset/wet-files-repeat.md
+++ b/.changeset/wet-files-repeat.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': minor
+---
+
+In Strapi projects, generate plugin in plugins path and log config info

--- a/src/cli/commands/plugin/init/action.ts
+++ b/src/cli/commands/plugin/init/action.ts
@@ -6,6 +6,8 @@ import gitUrlParse from 'git-url-parse';
 import path from 'node:path';
 import { outdent } from 'outdent';
 
+import { dirContainsStrapiProject, logInstructions } from '../../utils/helpers';
+
 import { gitIgnoreFile } from './files/gitIgnore';
 
 import type { CLIContext } from '../../../../types';
@@ -21,24 +23,49 @@ const USE_RC_VERSIONS: string[] = [
   '@strapi/typescript-utils',
 ] as const;
 
+// Store results of prompt answers (run by pack-up init)
+// This is a limitation of pack-up; we cannot run the prompt and pass the answers in
+let promptAnswers: any = [];
+
 export default async (
   packagePath: string,
   { silent, debug }: ActionOptions,
   { logger, cwd }: CLIContext
 ) => {
   try {
+    const isStrapi = dirContainsStrapiProject(cwd);
+
+    // If the user entered a path, we will try to parse the plugin name from it so we can provide it as a suggestion for consistency
+    const parsedPath = path.parse(packagePath);
+    const suggestedPackageName = parsedPath.base;
+    const isPathPackageName = !packagePath.includes('/');
+    const pluginPath = isStrapi && isPathPackageName ? `./src/plugins/${packagePath}` : packagePath;
+
+    //
+    const template = getPluginTemplate({ suggestedPackageName });
+
     /**
      * Create the package // plugin
      */
     await init({
-      path: packagePath,
+      path: pluginPath,
       cwd,
       silent,
       debug,
-      template: PLUGIN_TEMPLATE,
+      template,
     });
 
-    logger.info("Don't forget to enable your plugin in your configuration files.");
+    if (isStrapi) {
+      const pkgName = promptAnswers.find((option: any) => option?.name === 'pkgName')?.answer;
+
+      const language = promptAnswers.find((option: any) => option?.name === 'typescript')?.answer
+        ? 'ts'
+        : 'js';
+
+      logger.info(logInstructions(pkgName, { language, path: pluginPath }));
+    }
+
+    logger.info('Plugin generated successfully.');
   } catch (err) {
     logger.error(
       'There seems to be an unexpected error, try again with --debug for more information \n'
@@ -101,436 +128,448 @@ interface PluginPackageJson {
   };
 }
 
-const PLUGIN_TEMPLATE = defineTemplate(async ({ logger, gitConfig, packagePath }) => {
-  let repo: {
-    source?: string;
-    owner?: string;
-    name?: string;
-  };
+type PluginTemplateOptions = {
+  suggestedPackageName?: string;
+};
 
-  const [packageFolder] = packagePath.split(path.sep).slice(-1);
+const getPluginTemplate = ({ suggestedPackageName }: PluginTemplateOptions) => {
+  return defineTemplate(async ({ logger, gitConfig, packagePath }) => {
+    let repo: {
+      source?: string;
+      owner?: string;
+      name?: string;
+    };
 
-  if (!packagePath?.length || !packageFolder) {
-    throw new Error('Missing package path');
-  }
+    const [packageFolder] = packagePath.split(path.sep).slice(-1);
 
-  return {
-    prompts: [
-      definePackageOption({
-        name: 'repo',
-        type: 'text',
-        message: 'git url',
-        validate(val: unknown) {
-          if (!val) {
+    if (!packagePath?.length || !packageFolder) {
+      throw new Error('Missing package path');
+    }
+
+    return {
+      prompts: [
+        definePackageOption({
+          name: 'repo',
+          type: 'text',
+          message: 'git url',
+          validate(val: unknown) {
+            if (!val) {
+              return true;
+            }
+
+            try {
+              const result = gitUrlParse(val as any);
+
+              repo = { source: result.source, owner: result.owner, name: result.name };
+
+              return true;
+            } catch (err) {
+              return 'invalid git url';
+            }
+          },
+        }),
+        definePackageOption({
+          name: 'pkgName',
+          type: 'text',
+          message: 'plugin name',
+          initial: () => suggestedPackageName ?? repo?.name ?? '',
+          validate(val: unknown) {
+            if (!val || typeof val !== 'string') {
+              return 'package name is required';
+            }
+
+            const match = PACKAGE_NAME_REGEXP.exec(val);
+
+            if (!match) {
+              return 'invalid package name';
+            }
+
             return true;
-          }
-
-          try {
-            const result = gitUrlParse(val as any);
-
-            repo = { source: result.source, owner: result.owner, name: result.name };
+          },
+        }),
+        definePackageOption({
+          name: 'displayName',
+          type: 'text',
+          message: 'plugin display name',
+        }),
+        definePackageOption({
+          name: 'description',
+          type: 'text',
+          message: 'plugin description',
+        }),
+        definePackageOption({
+          name: 'authorName',
+          type: 'text',
+          message: 'plugin author name',
+          initial: gitConfig?.user?.name,
+        }),
+        definePackageOption({
+          name: 'authorEmail',
+          type: 'text',
+          message: 'plugin author email',
+          initial: gitConfig?.user?.email,
+        }),
+        definePackageOption({
+          name: 'license',
+          type: 'text',
+          message: 'plugin license',
+          initial: 'MIT',
+          validate(v) {
+            if (!v) {
+              return 'license is required';
+            }
 
             return true;
-          } catch (err) {
-            return 'invalid git url';
-          }
-        },
-      }),
-      definePackageOption({
-        name: 'pkgName',
-        type: 'text',
-        message: 'plugin name',
-        initial: () => repo?.name ?? '',
-        validate(val: unknown) {
-          if (!val || typeof val !== 'string') {
-            return 'package name is required';
-          }
+          },
+        }),
+        definePackageOption({
+          name: 'client-code',
+          type: 'confirm',
+          message: 'register with the admin panel?',
+          initial: true,
+        }),
+        definePackageOption({
+          name: 'server-code',
+          type: 'confirm',
+          message: 'register with the server?',
+          initial: true,
+        }),
+        definePackageFeature({
+          name: 'editorconfig',
+          initial: true,
+          optional: true,
+        }),
+        definePackageFeature({
+          name: 'eslint',
+          initial: true,
+          optional: true,
+        }),
+        definePackageFeature({
+          name: 'prettier',
+          initial: true,
+          optional: true,
+        }),
+        definePackageFeature({
+          name: 'typescript',
+          initial: true,
+          optional: true,
+        }),
+      ],
+      async getFiles(answers) {
+        const author: string[] = [];
 
-          const match = PACKAGE_NAME_REGEXP.exec(val);
+        const files: TemplateFile[] = [];
 
-          if (!match) {
-            return 'invalid package name';
-          }
+        // package.json
+        const pkgJson: PluginPackageJson = {
+          version: '0.0.0',
+          keywords: [],
+          type: 'commonjs',
+          exports: {
+            './package.json': './package.json',
+          },
+          files: ['dist'],
+          scripts: {
+            build: 'strapi-plugin build',
+            watch: 'strapi-plugin watch',
+            'watch:link': 'strapi-plugin watch:link',
+            verify: 'strapi-plugin verify',
+          },
+          dependencies: {},
+          devDependencies: {
+            /**
+             * We set * as a default version, but further down
+             * we try to resolve each package to their latest
+             * version, failing that we leave the fallback of *.
+             */
+            '@strapi/strapi': '*',
+            '@strapi/sdk-plugin': '*',
+            prettier: '*',
+          },
+          peerDependencies: {
+            // TODO: set this to 5.0.0 when Strapi 5 is released
+            '@strapi/strapi': '^5.0.0-beta',
+            '@strapi/sdk-plugin': '^5.0.0',
+          },
+          strapi: {
+            kind: 'plugin',
+          },
+        };
 
-          return true;
-        },
-      }),
-      definePackageOption({
-        name: 'displayName',
-        type: 'text',
-        message: 'plugin display name',
-      }),
-      definePackageOption({
-        name: 'description',
-        type: 'text',
-        message: 'plugin description',
-      }),
-      definePackageOption({
-        name: 'authorName',
-        type: 'text',
-        message: 'plugin author name',
-        initial: gitConfig?.user?.name,
-      }),
-      definePackageOption({
-        name: 'authorEmail',
-        type: 'text',
-        message: 'plugin author email',
-        initial: gitConfig?.user?.email,
-      }),
-      definePackageOption({
-        name: 'license',
-        type: 'text',
-        message: 'plugin license',
-        initial: 'MIT',
-        validate(v) {
-          if (!v) {
-            return 'license is required';
-          }
+        if (Array.isArray(answers)) {
+          for (const ans of answers) {
+            const { name, answer } = ans;
 
-          return true;
-        },
-      }),
-      definePackageOption({
-        name: 'client-code',
-        type: 'confirm',
-        message: 'register with the admin panel?',
-        initial: true,
-      }),
-      definePackageOption({
-        name: 'server-code',
-        type: 'confirm',
-        message: 'register with the server?',
-        initial: true,
-      }),
-      definePackageFeature({
-        name: 'editorconfig',
-        initial: true,
-        optional: true,
-      }),
-      definePackageFeature({
-        name: 'eslint',
-        initial: true,
-        optional: true,
-      }),
-      definePackageFeature({
-        name: 'prettier',
-        initial: true,
-        optional: true,
-      }),
-      definePackageFeature({
-        name: 'typescript',
-        initial: true,
-        optional: true,
-      }),
-    ],
-    async getFiles(answers) {
-      const author: string[] = [];
-
-      const files: TemplateFile[] = [];
-
-      // package.json
-      const pkgJson: PluginPackageJson = {
-        version: '0.0.0',
-        keywords: [],
-        type: 'commonjs',
-        exports: {
-          './package.json': './package.json',
-        },
-        files: ['dist'],
-        scripts: {
-          build: 'strapi-plugin build',
-          watch: 'strapi-plugin watch',
-          'watch:link': 'strapi-plugin watch:link',
-          verify: 'strapi-plugin verify',
-        },
-        dependencies: {},
-        devDependencies: {
-          /**
-           * We set * as a default version, but further down
-           * we try to resolve each package to their latest
-           * version, failing that we leave the fallback of *.
-           */
-          '@strapi/strapi': '*',
-          '@strapi/sdk-plugin': '*',
-          prettier: '*',
-        },
-        peerDependencies: {
-          // TODO: set this to 5.0.0 when Strapi 5 is released
-          '@strapi/strapi': '^5.0.0-beta',
-          '@strapi/sdk-plugin': '^5.0.0',
-        },
-        strapi: {
-          kind: 'plugin',
-        },
-      };
-
-      if (Array.isArray(answers)) {
-        for (const ans of answers) {
-          const { name, answer } = ans;
-
-          switch (name) {
-            case 'pkgName': {
-              pkgJson.name = String(answer);
-              pkgJson.strapi.name = String(answer);
-              break;
-            }
-            case 'description': {
-              pkgJson.description = String(answer) ?? undefined;
-              pkgJson.strapi.description = String(answer) ?? undefined;
-              break;
-            }
-            case 'displayName': {
-              pkgJson.strapi.displayName = String(answer) ?? undefined;
-              break;
-            }
-            case 'authorName': {
-              author.push(String(answer));
-              break;
-            }
-            case 'authorEmail': {
-              if (answer) {
-                author.push(`<${answer}>`);
+            switch (name) {
+              case 'pkgName': {
+                pkgJson.name = String(answer);
+                pkgJson.strapi.name = String(answer);
+                break;
               }
-              break;
-            }
-            case 'license': {
-              pkgJson.license = String(answer);
-              break;
-            }
-            case 'client-code': {
-              if (answer) {
-                pkgJson.exports['./strapi-admin'] = {
-                  source: './admin/src/index.js',
-                  import: './dist/admin/index.mjs',
-                  require: './dist/admin/index.js',
-                  default: './dist/admin/index.js',
-                };
-
-                pkgJson.dependencies = {
-                  ...pkgJson.dependencies,
-                  '@strapi/design-system': '*',
-                  '@strapi/icons': '*',
-                  'react-intl': '*',
-                };
-
-                pkgJson.devDependencies = {
-                  ...pkgJson.devDependencies,
-                  react: '*',
-                  'react-dom': '*',
-                  'react-router-dom': '*',
-                  'styled-components': '*',
-                };
-
-                pkgJson.peerDependencies = {
-                  ...pkgJson.peerDependencies,
-                  react: '^17.0.0 || ^18.0.0',
-                  'react-dom': '^17.0.0 || ^18.0.0',
-                  'react-router-dom': '^6.0.0',
-                  'styled-components': '^6.0.0',
-                };
+              case 'description': {
+                pkgJson.description = String(answer) ?? undefined;
+                pkgJson.strapi.description = String(answer) ?? undefined;
+                break;
               }
-
-              break;
-            }
-            case 'server-code': {
-              if (answer) {
-                pkgJson.exports['./strapi-server'] = {
-                  source: './server/src/index.js',
-                  import: './dist/server/index.mjs',
-                  require: './dist/server/index.js',
-                  default: './dist/server/index.js',
-                };
-
-                pkgJson.files.push('./strapi-server.js');
-
-                files.push({
-                  name: 'strapi-server.js',
-                  contents: outdent`
-                      'use strict';
-  
-                      module.exports = require('./dist/server');
-                  `,
-                });
+              case 'displayName': {
+                pkgJson.strapi.displayName = String(answer) ?? undefined;
+                break;
               }
-
-              break;
-            }
-            case 'typescript': {
-              const isTypescript = Boolean(answer);
-
-              if (isTypescript) {
-                if (isRecord(pkgJson.exports['./strapi-admin'])) {
-                  pkgJson.exports['./strapi-admin'].source = './admin/src/index.ts';
-
+              case 'authorName': {
+                author.push(String(answer));
+                break;
+              }
+              case 'authorEmail': {
+                if (answer) {
+                  author.push(`<${answer}>`);
+                }
+                break;
+              }
+              case 'license': {
+                pkgJson.license = String(answer);
+                break;
+              }
+              case 'client-code': {
+                if (answer) {
                   pkgJson.exports['./strapi-admin'] = {
-                    types: './dist/admin/src/index.d.ts',
-                    ...pkgJson.exports['./strapi-admin'],
+                    source: './admin/src/index.js',
+                    import: './dist/admin/index.mjs',
+                    require: './dist/admin/index.js',
+                    default: './dist/admin/index.js',
                   };
 
-                  pkgJson.scripts = {
-                    ...pkgJson.scripts,
-                    'test:ts:front': 'run -T tsc -p admin/tsconfig.json',
+                  pkgJson.dependencies = {
+                    ...pkgJson.dependencies,
+                    '@strapi/design-system': '*',
+                    '@strapi/icons': '*',
+                    'react-intl': '*',
                   };
 
                   pkgJson.devDependencies = {
                     ...pkgJson.devDependencies,
-                    '@types/react': '*',
-                    '@types/react-dom': '*',
+                    react: '*',
+                    'react-dom': '*',
+                    'react-router-dom': '*',
+                    'styled-components': '*',
                   };
 
-                  const { adminTsconfigFiles } = await import('./files/typescript');
+                  pkgJson.peerDependencies = {
+                    ...pkgJson.peerDependencies,
+                    react: '^17.0.0 || ^18.0.0',
+                    'react-dom': '^17.0.0 || ^18.0.0',
+                    'react-router-dom': '^6.0.0',
+                    'styled-components': '^6.0.0',
+                  };
+                }
 
-                  files.push(adminTsconfigFiles.tsconfigBuildFile, adminTsconfigFiles.tsconfigFile);
+                break;
+              }
+              case 'server-code': {
+                if (answer) {
+                  pkgJson.exports['./strapi-server'] = {
+                    source: './server/src/index.js',
+                    import: './dist/server/index.mjs',
+                    require: './dist/server/index.js',
+                    default: './dist/server/index.js',
+                  };
+
+                  pkgJson.files.push('./strapi-server.js');
+
+                  files.push({
+                    name: 'strapi-server.js',
+                    contents: outdent`
+                      'use strict';
+  
+                      module.exports = require('./dist/server');
+                  `,
+                  });
+                }
+
+                break;
+              }
+              case 'typescript': {
+                const isTypescript = Boolean(answer);
+
+                if (isTypescript) {
+                  if (isRecord(pkgJson.exports['./strapi-admin'])) {
+                    pkgJson.exports['./strapi-admin'].source = './admin/src/index.ts';
+
+                    pkgJson.exports['./strapi-admin'] = {
+                      types: './dist/admin/src/index.d.ts',
+                      ...pkgJson.exports['./strapi-admin'],
+                    };
+
+                    pkgJson.scripts = {
+                      ...pkgJson.scripts,
+                      'test:ts:front': 'run -T tsc -p admin/tsconfig.json',
+                    };
+
+                    pkgJson.devDependencies = {
+                      ...pkgJson.devDependencies,
+                      '@types/react': '*',
+                      '@types/react-dom': '*',
+                    };
+
+                    const { adminTsconfigFiles } = await import('./files/typescript');
+
+                    files.push(
+                      adminTsconfigFiles.tsconfigBuildFile,
+                      adminTsconfigFiles.tsconfigFile
+                    );
+                  }
+
+                  if (isRecord(pkgJson.exports['./strapi-server'])) {
+                    pkgJson.exports['./strapi-server'].source = './server/src/index.ts';
+
+                    pkgJson.exports['./strapi-server'] = {
+                      types: './dist/server/src/index.d.ts',
+                      ...pkgJson.exports['./strapi-server'],
+                    };
+
+                    pkgJson.scripts = {
+                      ...pkgJson.scripts,
+                      'test:ts:back': 'run -T tsc -p server/tsconfig.json',
+                    };
+
+                    const { serverTsconfigFiles } = await import('./files/typescript');
+
+                    files.push(
+                      serverTsconfigFiles.tsconfigBuildFile,
+                      serverTsconfigFiles.tsconfigFile
+                    );
+                  }
+
+                  pkgJson.devDependencies = {
+                    ...pkgJson.devDependencies,
+                    '@strapi/typescript-utils': '*',
+                    typescript: '*',
+                  };
+                }
+
+                /**
+                 * This is where we add all the source files regardless
+                 * of whether they are typescript or javascript.
+                 */
+                if (isRecord(pkgJson.exports['./strapi-admin'])) {
+                  files.push({
+                    name: isTypescript ? 'admin/src/pluginId.ts' : 'admin/src/pluginId.js',
+                    contents: outdent`
+                    export const PLUGIN_ID = '${pkgJson.name!.replace(/^strapi-plugin-/i, '')}';
+                  `,
+                  });
+
+                  if (isTypescript) {
+                    const { adminTypescriptFiles } = await import('./files/admin');
+
+                    files.push(...adminTypescriptFiles);
+                  } else {
+                    const { adminJavascriptFiles } = await import('./files/admin');
+
+                    files.push(...adminJavascriptFiles);
+                  }
                 }
 
                 if (isRecord(pkgJson.exports['./strapi-server'])) {
-                  pkgJson.exports['./strapi-server'].source = './server/src/index.ts';
+                  if (isTypescript) {
+                    const { serverTypescriptFiles } = await import('./files/server');
 
-                  pkgJson.exports['./strapi-server'] = {
-                    types: './dist/server/src/index.d.ts',
-                    ...pkgJson.exports['./strapi-server'],
-                  };
+                    files.push(...serverTypescriptFiles(packageFolder));
+                  } else {
+                    const { serverJavascriptFiles } = await import('./files/server');
 
-                  pkgJson.scripts = {
-                    ...pkgJson.scripts,
-                    'test:ts:back': 'run -T tsc -p server/tsconfig.json',
-                  };
-
-                  const { serverTsconfigFiles } = await import('./files/typescript');
-
-                  files.push(
-                    serverTsconfigFiles.tsconfigBuildFile,
-                    serverTsconfigFiles.tsconfigFile
-                  );
+                    files.push(...serverJavascriptFiles(packageFolder));
+                  }
                 }
 
-                pkgJson.devDependencies = {
-                  ...pkgJson.devDependencies,
-                  '@strapi/typescript-utils': '*',
-                  typescript: '*',
-                };
+                break;
               }
+              case 'eslint': {
+                if (answer) {
+                  const { eslintIgnoreFile } = await import('./files/eslint');
 
-              /**
-               * This is where we add all the source files regardless
-               * of whether they are typescript or javascript.
-               */
-              if (isRecord(pkgJson.exports['./strapi-admin'])) {
-                files.push({
-                  name: isTypescript ? 'admin/src/pluginId.ts' : 'admin/src/pluginId.js',
-                  contents: outdent`
-                    export const PLUGIN_ID = '${pkgJson.name!.replace(/^strapi-plugin-/i, '')}';
-                  `,
-                });
-
-                if (isTypescript) {
-                  const { adminTypescriptFiles } = await import('./files/admin');
-
-                  files.push(...adminTypescriptFiles);
-                } else {
-                  const { adminJavascriptFiles } = await import('./files/admin');
-
-                  files.push(...adminJavascriptFiles);
+                  files.push(eslintIgnoreFile);
                 }
+
+                break;
               }
+              case 'prettier': {
+                if (answer) {
+                  const { prettierFile, prettierIgnoreFile } = await import('./files/prettier');
 
-              if (isRecord(pkgJson.exports['./strapi-server'])) {
-                if (isTypescript) {
-                  const { serverTypescriptFiles } = await import('./files/server');
-
-                  files.push(...serverTypescriptFiles(packageFolder));
-                } else {
-                  const { serverJavascriptFiles } = await import('./files/server');
-
-                  files.push(...serverJavascriptFiles(packageFolder));
+                  files.push(prettierFile, prettierIgnoreFile);
                 }
+                break;
               }
+              case 'editorconfig': {
+                if (answer) {
+                  const { editorConfigFile } = await import('./files/editorConfig');
 
-              break;
-            }
-            case 'eslint': {
-              if (answer) {
-                const { eslintIgnoreFile } = await import('./files/eslint');
-
-                files.push(eslintIgnoreFile);
+                  files.push(editorConfigFile);
+                }
+                break;
               }
-
-              break;
+              default:
+                break;
             }
-            case 'prettier': {
-              if (answer) {
-                const { prettierFile, prettierIgnoreFile } = await import('./files/prettier');
-
-                files.push(prettierFile, prettierIgnoreFile);
-              }
-              break;
-            }
-            case 'editorconfig': {
-              if (answer) {
-                const { editorConfigFile } = await import('./files/editorConfig');
-
-                files.push(editorConfigFile);
-              }
-              break;
-            }
-            default:
-              break;
           }
         }
-      }
 
-      if (repo) {
-        pkgJson.repository = {
-          type: 'git',
-          url: `git+ssh://git@${repo.source}/${repo.owner}/${repo.name}.git`,
-        };
-        pkgJson.bugs = {
-          url: `https://${repo.source}/${repo.owner}/${repo.name}/issues`,
-        };
-        pkgJson.homepage = `https://${repo.source}/${repo.owner}/${repo.name}#readme`;
-      }
-
-      pkgJson.author = author.filter(Boolean).join(' ') ?? undefined;
-
-      try {
-        pkgJson.devDependencies = await resolveLatestVerisonOfDeps(pkgJson.devDependencies);
-        pkgJson.dependencies = await resolveLatestVerisonOfDeps(pkgJson.dependencies);
-        pkgJson.peerDependencies = await resolveLatestVerisonOfDeps(pkgJson.peerDependencies);
-      } catch (err) {
-        if (err instanceof Error) {
-          logger.error(err.message);
-        } else {
-          logger.error(err);
+        if (repo) {
+          pkgJson.repository = {
+            type: 'git',
+            url: `git+ssh://git@${repo.source}/${repo.owner}/${repo.name}.git`,
+          };
+          pkgJson.bugs = {
+            url: `https://${repo.source}/${repo.owner}/${repo.name}/issues`,
+          };
+          pkgJson.homepage = `https://${repo.source}/${repo.owner}/${repo.name}#readme`;
         }
-      }
 
-      files.push({
-        name: 'package.json',
-        contents: outdent`
+        pkgJson.author = author.filter(Boolean).join(' ') ?? undefined;
+
+        try {
+          pkgJson.devDependencies = await resolveLatestVersionOfDeps(pkgJson.devDependencies);
+          pkgJson.dependencies = await resolveLatestVersionOfDeps(pkgJson.dependencies);
+          pkgJson.peerDependencies = await resolveLatestVersionOfDeps(pkgJson.peerDependencies);
+        } catch (err) {
+          if (err instanceof Error) {
+            logger.error(err.message);
+          } else {
+            logger.error(err);
+          }
+        }
+
+        files.push({
+          name: 'package.json',
+          contents: outdent`
             ${JSON.stringify(pkgJson, null, 2)}
           `,
-      });
+        });
 
-      files.push({
-        name: 'README.md',
-        contents: outdent`
+        files.push({
+          name: 'README.md',
+          contents: outdent`
             # ${pkgJson.name}
 
             ${pkgJson.description ?? ''}
         `,
-      });
+        });
 
-      files.push(gitIgnoreFile);
+        files.push(gitIgnoreFile);
 
-      return files;
-    },
-  };
-});
+        // Save prompt answers so we have access to them after init
+        promptAnswers = answers;
+
+        return files;
+      },
+    };
+  });
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && !Array.isArray(value) && typeof value === 'object';
 
-const resolveLatestVerisonOfDeps = async (
+const resolveLatestVersionOfDeps = async (
   deps: Record<string, string>
 ): Promise<Record<string, string>> => {
   const latestDeps: Record<string, string> = {};

--- a/src/cli/commands/plugin/init/command.ts
+++ b/src/cli/commands/plugin/init/command.ts
@@ -9,7 +9,7 @@ const command: StrapiCommand = ({ command: commanderCommand, ctx }) => {
   commanderCommand
     .command('init')
     .description('Create a new plugin at a given path')
-    .argument('[path]', 'path to the plugin', './src/plugins/my-plugin')
+    .argument('path', 'path to the plugin')
     .option('-d, --debug', 'Enable debugging mode with verbose logs', false)
     .option('--silent', "Don't log anything", false)
     .action((path, options) => {

--- a/src/cli/commands/utils/helpers.ts
+++ b/src/cli/commands/utils/helpers.ts
@@ -23,8 +23,7 @@ export const dirContainsStrapiProject = (dir: string) => {
     const packageJsonPath = path.join(dir, 'package.json');
     const pkgJSON = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
     return Boolean(
-      (pkgJSON.dependencies && pkgJSON.dependencies['@strapi/strapi']) ||
-        (pkgJSON.devDependencies && pkgJSON.devDependencies['@strapi/strapi'])
+      pkgJSON.dependencies?.['@strapi/strapi'] || pkgJSON.devDependencies?.['@strapi/strapi']
     );
   } catch (err) {
     return false;
@@ -33,7 +32,7 @@ export const dirContainsStrapiProject = (dir: string) => {
 
 export const logInstructions = (
   pluginName: string,
-  { language, path: pluginPath }: { language: string; path?: string }
+  { language, path: pluginPath }: { language: string; path: string }
 ) => {
   const maxLength = `    resolve: './src/plugins/${pluginName}'`.length;
   const separator = Array(maxLength).fill('─').join('');
@@ -49,7 +48,7 @@ ${exportInstruction} {
   ${chalk.gray('// ...')}
   ${chalk.green(`'${pluginName}'`)}: {
     enabled: ${chalk.yellow(true)},
-    resolve: '${chalk.yellow(pluginPath || `./src/plugins/${pluginName}`)}'
+    resolve: '${chalk.yellow(pluginPath)}'
   },
   ${chalk.gray('// ...')}
 }

--- a/src/cli/commands/utils/helpers.ts
+++ b/src/cli/commands/utils/helpers.ts
@@ -49,7 +49,7 @@ ${exportInstruction} {
   ${chalk.gray('// ...')}
   ${chalk.green(`'${pluginName}'`)}: {
     enabled: ${chalk.yellow(true)},
-    resolve: ${chalk.yellow(pluginPath || `'./src/plugins/${pluginName}'`)}
+    resolve: '${chalk.yellow(pluginPath || `./src/plugins/${pluginName}`)}'
   },
   ${chalk.gray('// ...')}
 }

--- a/src/cli/commands/utils/helpers.ts
+++ b/src/cli/commands/utils/helpers.ts
@@ -1,6 +1,10 @@
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+
 import type { CLIContext } from '../../../types';
 
-const runAction =
+export const runAction =
   (name: string, action: (...args: any[]) => Promise<void>) =>
   (ctx: CLIContext, ...args: unknown[]) => {
     const { logger } = ctx;
@@ -14,4 +18,41 @@ const runAction =
       });
   };
 
-export { runAction };
+export const dirContainsStrapiProject = (dir: string) => {
+  try {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const pkgJSON = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    return Boolean(
+      (pkgJSON.dependencies && pkgJSON.dependencies['@strapi/strapi']) ||
+        (pkgJSON.devDependencies && pkgJSON.devDependencies['@strapi/strapi'])
+    );
+  } catch (err) {
+    return false;
+  }
+};
+
+export const logInstructions = (
+  pluginName: string,
+  { language, path: pluginPath }: { language: string; path?: string }
+) => {
+  const maxLength = `    resolve: './src/plugins/${pluginName}'`.length;
+  const separator = Array(maxLength).fill('─').join('');
+
+  const exportInstruction = language === 'js' ? 'module.exports =' : 'export default';
+
+  return `
+You can now enable your plugin by adding the following in ${chalk.yellow(
+    `./config/plugins.${language}`
+  )}
+${separator}
+${exportInstruction} {
+  ${chalk.gray('// ...')}
+  ${chalk.green(`'${pluginName}'`)}: {
+    enabled: ${chalk.yellow(true)},
+    resolve: ${chalk.yellow(pluginPath || `'./src/plugins/${pluginName}'`)}
+  },
+  ${chalk.gray('// ...')}
+}
+${separator}
+`;
+};


### PR DESCRIPTION
### What does it do?

When `init` is run in Strapi project, create plugin in plugin path and log the config info

### Why is it needed?

Makes `init` command more helpful

### How to test it?

run `init` in the root of a Strapi project and it should generate the plugin in the ./src/plugins dir automatically instead of in the root of the project and it should:
- suggest the path you provided as a packageName
- output lines to add to plugins.ts or plugins.js [check that extension is correct]
- have correct plugin config info even when path and packageName are different

run `init` anywhere else and it should:
- suggest the path you provided as a packageName
- NOT output lines to add to plugins config

### Related issue(s)/PR(s)

implements #22

DX-1521