### PR TITLE
chore: fix package name in CI bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -9,12 +9,12 @@ body:
         Thank you for filing a bug report!
   - type: textarea
     attributes:
-      label: What version of `@strapi/blocks-react-renderer` are you using?
+      label: What version of `@strapi/sdk-plugin` are you using?
       placeholder: |
         - Npm version
         - Node.js version
         - React version:
-        - `@strapi/blocks-react-renderer` version
+        - `@strapi/sdk-plugin` version
         - Browser
     validations:
       required: true


### PR DESCRIPTION
### What does it do?

fixes package name in github bug report suggested text

### Why is it needed?
it was wrong

### How to test it?

I don't think you can until after it's merged

### Related issue(s)/PR(s)
