### PR TITLE
chore: upgrade github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           cache: pnpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm prettier:check
       - run: pnpm test:ts
       - run: pnpm build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Cache build output
         with:
           name: build-output
@@ -46,14 +46,14 @@ jobs:
 #         node: [18, 20]
 #     steps:
 #       - uses: actions/checkout@v4
-#       - uses: pnpm/action-setup@v3
+#       - uses: pnpm/action-setup@v4
 #       - uses: actions/setup-node@v4
 #         with:
 #           cache: pnpm
 #           node-version: ${{ matrix.node }}
 #       - run: corepack enable && pnpm --version
 #       - run: pnpm install
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         name: Restore build output
 #         with:
 #           name: build-output


### PR DESCRIPTION
### What does it do?

upgrades deprecated github actions

### Why is it needed?

they were deprecated

### How to test it?

actions should still run succesfully and without deprecations notices

### Related issue(s)/PR(s)

none
