### PR TITLE
Upgrade max version Node.js to the next LTS 

### DIFF
--- a/.changeset/poor-bugs-sparkle.md
+++ b/.changeset/poor-bugs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+Add support for Node 22

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "packageManager": "pnpm@9.1.0",
   "engines": {
-    "node": ">=18.0.0 <=20.x.x",
+    "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"
   }
 }


### PR DESCRIPTION
👋 

### What does it do?

Remove the max version of Node inside `engines`

### Why is it needed?

- Node.js 22 is the next LTS, _soon_ 
- `@strapi/sdk-plugin@5.1.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0 <=20.x.x". Got "22.6.0"` 🔥 
- While having a limit to prevent people from using something too old makes sense, the other one is a bit weird. It makes sense to work on a newer version to ensure we can move to the next LTS without issues. 


### How to test it?

Run `yarn` 

### Related issue(s)/PR(s)

N/A

🙏 thx