### PR TITLE
fix/missing-commonjs

### DIFF
--- a/.changeset/rich-hairs-smell.md
+++ b/.changeset/rich-hairs-smell.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+fix missing commonjs plugin

--- a/src/cli/commands/plugin/watch.ts
+++ b/src/cli/commands/plugin/watch.ts
@@ -1,3 +1,4 @@
+import commonjs from '@rollup/plugin-commonjs';
 import { watch } from '@strapi/pack-up';
 import boxen from 'boxen';
 import chalk from 'chalk';
@@ -67,6 +68,7 @@ const action = async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLICo
       cwd,
       configFile: false,
       config: {
+        plugins: [commonjs()],
         bundles,
         dist: './dist',
         /**


### PR DESCRIPTION
### What does it do?

Fix missing rollup commonjs support during watch copying the changes done for the build command. 