### PR TITLE
chore: remove strapi-server file from generate plugin

### DIFF
--- a/.changeset/light-squids-wash.md
+++ b/.changeset/light-squids-wash.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore: remove strapi-server file from generate plugin

--- a/src/cli/commands/plugin/init/action.ts
+++ b/src/cli/commands/plugin/init/action.ts
@@ -395,17 +395,6 @@ const getPluginTemplate = ({ suggestedPackageName }: PluginTemplateOptions) => {
                     require: './dist/server/index.js',
                     default: './dist/server/index.js',
                   };
-
-                  pkgJson.files.push('./strapi-server.js');
-
-                  files.push({
-                    name: 'strapi-server.js',
-                    contents: outdent`
-                      'use strict';
-
-                      module.exports = require('./dist/server');
-                  `,
-                  });
                 }
 
                 break;


### PR DESCRIPTION
### What does it do?

Describe the technical changes you did.

### Why is it needed?

Once https://github.com/strapi/strapi/pull/21194 is merged and released, plugins won't need a mandatory `strapi-server.js` file