### PR TITLE
chore: make react deps compatible with design system

### DIFF
--- a/.changeset/big-garlics-run.md
+++ b/.changeset/big-garlics-run.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': minor
+---
+
+make react deps compatible with design system

--- a/src/cli/commands/plugin/init/action.ts
+++ b/src/cli/commands/plugin/init/action.ts
@@ -364,10 +364,10 @@ const getPluginTemplate = ({ suggestedPackageName }: PluginTemplateOptions) => {
 
                   pkgJson.devDependencies = {
                     ...pkgJson.devDependencies,
-                    react: '*',
-                    'react-dom': '*',
-                    'react-router-dom': '*',
-                    'styled-components': '*',
+                    react: '^17.0.0 || ^18.0.0',
+                    'react-dom': '^17.0.0 || ^18.0.0',
+                    'react-router-dom': '^6.0.0',
+                    'styled-components': '^6.0.0',
                   };
 
                   pkgJson.peerDependencies = {


### PR DESCRIPTION
### What does it do?

The linked issues describes how the plugin init phase fails as it cannot resolve the react dependencies between this repo and the design system

This PR specifies package versions that should be compatible with the DS

### How to test it?

./sdk-plugin/bin/strapi-plugin.js init plugin-name

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/sdk-plugin/issues/68
