### PR TITLE
fix: update packageJsonSchema to allow .d.ts files in validation

### DIFF
--- a/.changeset/blue-crabs-matter.md
+++ b/.changeset/blue-crabs-matter.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': minor
+---
+
+change package json exports validation rules

--- a/src/cli/commands/plugin/build.ts
+++ b/src/cli/commands/plugin/build.ts
@@ -19,7 +19,7 @@ const action = async ({ ...opts }: BuildCLIOptions, _cmd: unknown, { logger, cwd
     process.env.NODE_ENV = 'production';
 
     const pkg = await loadPkg({ cwd, logger });
-    const pkgJson = await validatePkg({ pkg });
+    const pkgJson = await validatePkg({ pkg, logger });
 
     if (!pkgJson.exports['./strapi-admin'] && !pkgJson.exports['./strapi-server']) {
       throw new Error(

--- a/src/cli/commands/plugin/link-watch.ts
+++ b/src/cli/commands/plugin/link-watch.ts
@@ -25,7 +25,7 @@ const action = async (_opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIC
     }
 
     const pkg = await loadPkg({ cwd, logger });
-    const pkgJson = await validatePkg({ pkg });
+    const pkgJson = await validatePkg({ pkg, logger });
 
     logger.info(
       outdent`

--- a/src/cli/commands/plugin/watch.ts
+++ b/src/cli/commands/plugin/watch.ts
@@ -16,7 +16,7 @@ type ActionOptions = WatchCLIOptions;
 const action = async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {
     const pkg = await loadPkg({ cwd, logger });
-    const pkgJson = await validatePkg({ pkg });
+    const pkgJson = await validatePkg({ pkg, logger });
 
     if (!pkgJson.exports['./strapi-admin'] && !pkgJson.exports['./strapi-server']) {
       throw new Error(

--- a/src/cli/commands/utils/pkg.ts
+++ b/src/cli/commands/utils/pkg.ts
@@ -36,7 +36,7 @@ const packageJsonSchema = yup.object({
               } else {
                 acc[key] = yup
                   .string()
-                  .matches(/^\.\/.*\.json$/)
+                  .matches(/^\.\/.*\.(json|d\.ts)$/)
                   .required();
               }
 


### PR DESCRIPTION
### What does it do?

The changes modify the packageJsonSchema to allow for more flexible export definitions

### Why is it needed?

To address https://github.com/strapi/sdk-plugin/issues/73

### Related issue(s)/PR(s)

fixes #73 