### PR TITLE
fix: allow any file extension in exports string

### DIFF
--- a/.changeset/smart-eyes-cross.md
+++ b/.changeset/smart-eyes-cross.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+fix: allow any file extension in exports string

--- a/src/cli/commands/utils/pkg.ts
+++ b/src/cli/commands/utils/pkg.ts
@@ -34,10 +34,7 @@ const packageJsonSchema = yup.object({
                   })
                   .noUnknown(true);
               } else {
-                acc[key] = yup
-                  .string()
-                  .matches(/^\.\/.*\.json$/)
-                  .required();
+                acc[key] = yup.string().required();
               }
 
               return acc;


### PR DESCRIPTION
### What does it do?

removes the filename matching from exports validation

### Why is it needed?

To address https://github.com/strapi/sdk-plugin/issues/73

### Related issue(s)/PR(s)

fixes #73 