### PR TITLE
ci: remove corepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-      - run: corepack enable && pnpm --version
+      - run: pnpm --version
       - run: pnpm install
       - run: pnpm build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-      - run: corepack enable && pnpm --version
+      - run: pnpm --version
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm prettier:check
@@ -51,7 +51,7 @@ jobs:
 #         with:
 #           cache: pnpm
 #           node-version: ${{ matrix.node }}
-#       - run: corepack enable && pnpm --version
+#       - run: pnpm --version
 #       - run: pnpm install
 #       - uses: actions/download-artifact@v4
 #         name: Restore build output


### PR DESCRIPTION
### What does it do?

removes corepack

### Why is it needed?

it was breaking and it isn't necessary; pnpm/setup-action takes care of it

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
