### PR TITLE
chore: add missing changeset to trigger release

### DIFF
--- a/.changeset/silver-shoes-fly.md
+++ b/.changeset/silver-shoes-fly.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': minor
+---
+
+remove maximum node version from engines to allow node 24


### PR DESCRIPTION
### What does it do?

The latest commit (https://github.com/strapi/sdk-plugin/commit/ea6e9a473379dac6465d1b510df62f0306036407) introduced in #114 didn't have a changeset thus not triggering a release.

I added one as I assume this will start the release pipeline.

### Why is it needed?

To get a new release allowing us to update to node@24

### How to test it?

n.a.

### Related issue(s)/PR(s)

#114
