### PR TITLE
chore: add .vscode directory to gitignore

### DIFF
--- a/.changeset/gitignore-vscode-directory.md
+++ b/.changeset/gitignore-vscode-directory.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': patch
+---
+
+Repository maintenance: add `.vscode/` to `.gitignore` alongside other IDE paths. No change to published package contents.

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ $RECYCLE.BIN/
 
 *#
 .idea
+.vscode/
 nbproject
 
 ############################


### PR DESCRIPTION
### What does it do?

Adds `.vscode/` to the **Misc.** section of `.gitignore` next to `.idea` and `nbproject`, and adds a Changesets patch entry for `@strapi/sdk-plugin`.

### Why is it needed?

Local VS Code / Cursor workspace settings under `.vscode` should not be committed; ignoring the directory keeps contributor machine-specific configuration out of the repository.

### How to test it?

Clone or use this branch, confirm `git status` no longer lists tracked changes under `.vscode/` when only local settings exist, and run `pnpm lint` / `pnpm prettier:check` if you want to mirror CI (no functional code paths changed).

### Related issue(s)/PR(s)

N/A
