### PR TITLE
chore: ignore .pnpm-store directory

### DIFF
--- a/.changeset/gitignore-pnpm-store.md
+++ b/.changeset/gitignore-pnpm-store.md
@@ -1,0 +1,5 @@
+---
+'@strapi/sdk-plugin': patch
+---
+
+Repository maintenance: add `.pnpm-store/` to `.gitignore` so local pnpm store directories are not tracked. No change to published package contents.

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ logs
 results
 dist
 node_modules
+.pnpm-store/
 .node_history
 package-lock.json
 


### PR DESCRIPTION
### What does it do?

Adds `.pnpm-store/` to the repository `.gitignore` so a project-local pnpm content-addressed store is never tracked as source changes. Includes a patch Changeset noting repository-only maintenance (no change to published package code).

### Why is it needed?

When pnpm uses or creates a `.pnpm-store` directory inside the repo (for example with certain store layouts or tooling), Git would otherwise surface it as untracked or accidental commits. Ignoring it matches existing ignores such as `node_modules` and keeps contributor working trees clean.

### How to test it?

Check out this branch and run `git status` with a local `.pnpm-store/` present (if applicable): the path should be ignored. No CLI or build behavior changes; optional: `pnpm install`, `pnpm lint`, and `pnpm build` still succeed as on `main`.

### Related issue(s)/PR(s)

None.
