### PR TITLE
ci: add node 26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -53,7 +53,7 @@ jobs:
       # A test failing on windows doesn't mean it'll fail on macos. It's useful to let all tests run to its completion to get the full picture
       fail-fast: false
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6


### PR DESCRIPTION
### What does it do?

adds node 26 to the test matrix

### Why is it needed?

to ensure everything works with Node 26 

### How to test it?

CI should pass; client should work with node 26

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
