### PR TITLE
fix(ci): stabilize unit tests on Node 26 CI

### DIFF
--- a/src/__tests__/e2e/build.test.ts
+++ b/src/__tests__/e2e/build.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { build } from '../../cli/commands/utils/build';
 import { createLogger } from '../../cli/commands/utils/logger';
 
-import { getFixturePath, invokeCLI, withMockedCLI } from './test-utils';
+import { BUILD_TEST_TIMEOUT_MS, getFixturePath, invokeCLI, withMockedCLI } from './test-utils';
 
 describe('build command', () => {
   it('should validate package.json before building', async () => {
@@ -50,6 +50,8 @@ describe('build command', () => {
   });
 
   describe('custom exports', () => {
+    jest.setTimeout(BUILD_TEST_TIMEOUT_MS);
+
     const fixturePath = getFixturePath('custom-export-plugin');
     const distTypesDir = path.join(fixturePath, 'dist/types');
     const distServerDir = path.join(fixturePath, 'dist/server');

--- a/src/__tests__/e2e/test-utils.ts
+++ b/src/__tests__/e2e/test-utils.ts
@@ -6,6 +6,9 @@ import path from 'node:path';
  */
 export const fixturesDir = path.join(__dirname, '../fixtures');
 
+/** Vite builds in e2e tests can exceed Jest's 5s default on slower CI Node versions. */
+export const BUILD_TEST_TIMEOUT_MS = 15_000;
+
 export function getFixturePath(fixtureName: string): string {
   return path.join(fixturesDir, fixtureName);
 }

--- a/src/__tests__/e2e/test-utils.ts
+++ b/src/__tests__/e2e/test-utils.ts
@@ -41,6 +41,21 @@ export async function withMockedCLI(fixtureName: string, testFn: TestCallback): 
 }
 
 /**
+ * Builds a plugin fixture so verify (and other dist-dependent commands) succeed in CI,
+ * where fixture dist/ is not checked in because the repo root .gitignore ignores dist.
+ */
+export async function ensureFixtureBuilt(fixtureName: string): Promise<void> {
+  const { build } = await import('../../cli/commands/utils/build');
+  const { createLogger } = await import('../../cli/commands/utils/logger');
+
+  await build({
+    cwd: getFixturePath(fixtureName),
+    logger: createLogger({ silent: true, debug: false, timestamp: false }),
+    silent: true,
+  });
+}
+
+/**
  * Invokes the CLI with given arguments and returns the command instance.
  */
 export async function invokeCLI(args: string[], command?: Command): Promise<Command> {

--- a/src/__tests__/e2e/verify.test.ts
+++ b/src/__tests__/e2e/verify.test.ts
@@ -1,17 +1,21 @@
-import { ensureFixtureBuilt, invokeCLI, withMockedCLI } from './test-utils';
+import { BUILD_TEST_TIMEOUT_MS, ensureFixtureBuilt, invokeCLI, withMockedCLI } from './test-utils';
 
 describe('verify command', () => {
-  it('should verify a valid TypeScript plugin', async () => {
-    await ensureFixtureBuilt('typescript-plugin');
+  it(
+    'should verify a valid TypeScript plugin',
+    async () => {
+      await ensureFixtureBuilt('typescript-plugin');
 
-    await withMockedCLI('typescript-plugin', async ({ command, mockExit }) => {
-      const cli = await invokeCLI(['verify', '--silent'], command);
+      await withMockedCLI('typescript-plugin', async ({ command, mockExit }) => {
+        const cli = await invokeCLI(['verify', '--silent'], command);
 
-      await cli.parseAsync(['node', 'strapi-plugin', 'verify', '--silent']);
+        await cli.parseAsync(['node', 'strapi-plugin', 'verify', '--silent']);
 
-      expect(mockExit).not.toHaveBeenCalled();
-    });
-  });
+        expect(mockExit).not.toHaveBeenCalled();
+      });
+    },
+    BUILD_TEST_TIMEOUT_MS
+  );
 
   it('should fail for plugin with invalid exports', async () => {
     await withMockedCLI('typescript-plugin', async () => {

--- a/src/__tests__/e2e/verify.test.ts
+++ b/src/__tests__/e2e/verify.test.ts
@@ -1,7 +1,9 @@
-import { invokeCLI, withMockedCLI } from './test-utils';
+import { ensureFixtureBuilt, invokeCLI, withMockedCLI } from './test-utils';
 
 describe('verify command', () => {
   it('should verify a valid TypeScript plugin', async () => {
+    await ensureFixtureBuilt('typescript-plugin');
+
     await withMockedCLI('typescript-plugin', async ({ command, mockExit }) => {
       const cli = await invokeCLI(['verify', '--silent'], command);
 

--- a/src/__tests__/e2e/verify.test.ts
+++ b/src/__tests__/e2e/verify.test.ts
@@ -5,9 +5,7 @@ describe('verify command', () => {
     await withMockedCLI('typescript-plugin', async ({ command, mockExit }) => {
       const cli = await invokeCLI(['verify', '--silent'], command);
 
-      await expect(
-        cli.parseAsync(['node', 'strapi-plugin', 'verify', '--silent'])
-      ).resolves.not.toThrow();
+      await cli.parseAsync(['node', 'strapi-plugin', 'verify', '--silent']);
 
       expect(mockExit).not.toHaveBeenCalled();
     });

--- a/src/__tests__/unit/validation-check.test.ts
+++ b/src/__tests__/unit/validation-check.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 const fixturesRoot = path.join(__dirname, '..', 'fixtures');
@@ -23,16 +25,23 @@ describe('validation.check', () => {
     const { build } = await import('../../cli/commands/utils/build');
     const { verify } = await import('../../cli/commands/utils/validation');
     const logger = createLogger();
-    const cwd = path.join(fixturesRoot, 'typescript-plugin');
+    const fixtureSource = path.join(fixturesRoot, 'typescript-plugin');
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'strapi-sdk-plugin-validation-'));
 
-    await build({
-      cwd,
-      logger,
-      silent: true,
-    });
+    try {
+      await fs.cp(fixtureSource, cwd, { recursive: true });
 
-    await expect(verify({ cwd, logger })).resolves.toBeUndefined();
-  });
+      await build({
+        cwd,
+        logger,
+        silent: true,
+      });
+
+      await expect(verify({ cwd, logger })).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   it('fails when no strapi-admin or strapi-server exports exist', async () => {
     const { verify } = await import('../../cli/commands/utils/validation');

--- a/src/__tests__/unit/validation-check.test.ts
+++ b/src/__tests__/unit/validation-check.test.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { BUILD_TEST_TIMEOUT_MS } from '../e2e/test-utils';
+
 const fixturesRoot = path.join(__dirname, '..', 'fixtures');
 
 const createLogger = () => ({
@@ -21,27 +23,31 @@ const createLogger = () => ({
 });
 
 describe('validation.check', () => {
-  it('passes for a valid plugin fixture (exports ordered + files exist)', async () => {
-    const { build } = await import('../../cli/commands/utils/build');
-    const { verify } = await import('../../cli/commands/utils/validation');
-    const logger = createLogger();
-    const fixtureSource = path.join(fixturesRoot, 'typescript-plugin');
-    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'strapi-sdk-plugin-validation-'));
+  it(
+    'passes for a valid plugin fixture (exports ordered + files exist)',
+    async () => {
+      const { build } = await import('../../cli/commands/utils/build');
+      const { verify } = await import('../../cli/commands/utils/validation');
+      const logger = createLogger();
+      const fixtureSource = path.join(fixturesRoot, 'typescript-plugin');
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'strapi-sdk-plugin-validation-'));
 
-    try {
-      await fs.cp(fixtureSource, cwd, { recursive: true });
+      try {
+        await fs.cp(fixtureSource, cwd, { recursive: true });
 
-      await build({
-        cwd,
-        logger,
-        silent: true,
-      });
+        await build({
+          cwd,
+          logger,
+          silent: true,
+        });
 
-      await expect(verify({ cwd, logger })).resolves.toBeUndefined();
-    } finally {
-      await fs.rm(cwd, { recursive: true, force: true });
-    }
-  }, 15_000);
+        await expect(verify({ cwd, logger })).resolves.toBeUndefined();
+      } finally {
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    },
+    BUILD_TEST_TIMEOUT_MS
+  );
 
   it('fails when no strapi-admin or strapi-server exports exist', async () => {
     const { verify } = await import('../../cli/commands/utils/validation');

--- a/src/cli/commands/utils/helpers.ts
+++ b/src/cli/commands/utils/helpers.ts
@@ -23,10 +23,8 @@ export const runAction =
   (name: string, action: (...args: any[]) => Promise<void>) =>
   (ctx: CLIContext, ...args: unknown[]) => {
     const { logger } = ctx;
-    Promise.resolve()
-      .then(() => {
-        return action(...args, ctx);
-      })
+    return Promise.resolve()
+      .then(() => action(...args, ctx))
       .catch((error) => {
         logger.error(error);
         process.exit(1);


### PR DESCRIPTION
## Summary

- Return the promise from `runAction` so Commander `parseAsync` waits for CLI handlers to finish (fixes Jest teardown races on Node 26).
- Run the `validation.check` build+verify test against a temp copy of the `typescript-plugin` fixture with a 15s timeout (avoids parallel contention on shared `dist/`).
- Build the `typescript-plugin` fixture before the verify e2e test via `ensureFixtureBuilt()` — fixture `dist/` is gitignored, so fresh CI checkouts had no export files and verify correctly failed once `runAction` started awaiting.

## Test plan

- [x] `pnpm test:unit` passes with fixture `dist/` removed (CI-like checkout)
- [x] `pnpm test:unit --maxWorkers=4` run 3× without flakes
- [x] CI `test:unit (22)`, `(24)`, and `(26)` all green