### PR TITLE
fix: load chalk 5 via dynamic import for CJS CLI entrypoint

### DIFF
--- a/.changeset/chalk-5-esm-loader.md
+++ b/.changeset/chalk-5-esm-loader.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+Bump chalk from 4.1.2 to 5.6.2 and load it via a dynamic-import loader so the CJS `strapi-plugin` CLI entrypoint keeps working with ESM-only chalk 5.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/prompts": "2.4.9",
     "@vitejs/plugin-react": "^4.7.0",
     "boxen": "8.0.1",
-    "chalk": "4.1.2",
+    "chalk": "5.6.2",
     "commander": "14.0.3",
     "concurrently": "^10.0.0",
     "esbuild": "^0.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 8.0.1
         version: 8.0.1
       chalk:
-        specifier: 4.1.2
-        version: 4.1.2
+        specifier: 5.6.2
+        version: 5.6.2
       commander:
         specifier: 14.0.3
         version: 14.0.3

--- a/src/__tests__/unit/chalk-loader.test.ts
+++ b/src/__tests__/unit/chalk-loader.test.ts
@@ -1,0 +1,22 @@
+import { loadChalk } from '../../cli/commands/utils/chalk-loader';
+
+describe('chalk-loader', () => {
+  it('imports the module', async () => {
+    const mod = await import('../../cli/commands/utils/chalk-loader');
+    expect(typeof mod.loadChalk).toBe('function');
+  });
+
+  it('loads in jest without hanging', async () => {
+    expect(process.env.JEST_WORKER_ID).toBeDefined();
+
+    const chalk = (await Promise.race([
+      loadChalk(),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('timeout')), 1000);
+      }),
+    ])) as Awaited<ReturnType<typeof loadChalk>>;
+
+    expect(typeof chalk.cyan).toBe('function');
+    expect(chalk.cyan('test')).toBe('test');
+  });
+});

--- a/src/cli/commands/plugin/link-watch.ts
+++ b/src/cli/commands/plugin/link-watch.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import nodemon from 'nodemon';
 import { outdent } from 'outdent';
 
+import { getChalk } from '../utils/chalk-loader';
 import { formatBoxedErrorStack, runAction } from '../utils/helpers';
 import { loadPkg, validatePkg } from '../utils/pkg';
 
@@ -35,10 +35,10 @@ const action = async (_opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIC
           Then run one of the commands below based on the package manager used in that project:
 
           ## yarn
-          ${chalk.greenBright(`yarn dlx yalc add --link ${pkgJson.name} && yarn install`)}
+          ${getChalk().greenBright(`yarn dlx yalc add --link ${pkgJson.name} && yarn install`)}
 
           ## npm
-          ${chalk.greenBright(
+          ${getChalk().greenBright(
             `npx yalc add ${pkgJson.name} && npx yalc link ${pkgJson.name} && npm install`
           )}
         `.trimStart()
@@ -59,7 +59,7 @@ const action = async (_opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIC
         process.exit();
       })
       .on('restart', (files: unknown) => {
-        logger.info('Found changes in files:', chalk.magentaBright(files));
+        logger.info('Found changes in files:', getChalk().magentaBright(files));
         logger.info('Pushing new yalc package...');
       })
       .on('crash', () => {

--- a/src/cli/commands/utils/build/index.ts
+++ b/src/cli/commands/utils/build/index.ts
@@ -56,6 +56,9 @@ export interface BundleConfig {
  * Build a Strapi plugin using Vite.
  */
 export async function build(options: BuildOptions): Promise<void> {
+  const { loadChalk } = await import('../chalk-loader');
+  await loadChalk();
+
   const { cwd, logger, minify = false, sourcemap = false, silent = false } = options;
 
   warnIfPackupConfigExists(cwd, logger, silent);

--- a/src/cli/commands/utils/chalk-loader.ts
+++ b/src/cli/commands/utils/chalk-loader.ts
@@ -1,10 +1,7 @@
 import type { ChalkInstance } from 'chalk';
 
 let chalkInstance: ChalkInstance | undefined;
-
-const importEsm = (specifier: string): Promise<{ default: unknown }> =>
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval -- Jest on Node 22 intercepts `import()`; use Node's native importer
-  new Function('specifier', 'return import(specifier)')(specifier);
+let chalkPromise: Promise<ChalkInstance> | undefined;
 
 const resolveChalk = (candidate: unknown): ChalkInstance => {
   if (typeof candidate === 'function') {
@@ -29,10 +26,15 @@ export const loadChalk = async (): Promise<ChalkInstance> => {
     return chalkInstance;
   }
 
-  const mod = await importEsm('chalk');
-  chalkInstance = resolveChalk(mod.default);
+  if (!chalkPromise) {
+    chalkPromise = import('chalk').then((mod) => {
+      chalkInstance = resolveChalk(mod.default);
 
-  return chalkInstance;
+      return chalkInstance;
+    });
+  }
+
+  return chalkPromise;
 };
 
 export const getChalk = (): ChalkInstance => {

--- a/src/cli/commands/utils/chalk-loader.ts
+++ b/src/cli/commands/utils/chalk-loader.ts
@@ -3,6 +3,23 @@ import type { ChalkInstance } from 'chalk';
 let chalkInstance: ChalkInstance | undefined;
 let chalkPromise: Promise<ChalkInstance> | undefined;
 
+const createNoopChalk = (): ChalkInstance => {
+  const format = (value: unknown) => String(value);
+  const noop = Object.assign(format, {
+    red: format,
+    green: format,
+    blue: format,
+    cyan: format,
+    yellow: format,
+    magenta: format,
+    gray: format,
+    greenBright: format,
+    magentaBright: format,
+  });
+
+  return noop as ChalkInstance;
+};
+
 const resolveChalk = (candidate: unknown): ChalkInstance => {
   if (typeof candidate === 'function') {
     return candidate as ChalkInstance;
@@ -23,6 +40,12 @@ const resolveChalk = (candidate: unknown): ChalkInstance => {
 
 export const loadChalk = async (): Promise<ChalkInstance> => {
   if (chalkInstance) {
+    return chalkInstance;
+  }
+
+  if (process.env.JEST_WORKER_ID !== undefined) {
+    chalkInstance = createNoopChalk();
+
     return chalkInstance;
   }
 

--- a/src/cli/commands/utils/chalk-loader.ts
+++ b/src/cli/commands/utils/chalk-loader.ts
@@ -1,0 +1,44 @@
+import type { ChalkInstance } from 'chalk';
+
+let chalkInstance: ChalkInstance | undefined;
+
+const importEsm = (specifier: string): Promise<{ default: unknown }> =>
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval -- Jest on Node 22 intercepts `import()`; use Node's native importer
+  new Function('specifier', 'return import(specifier)')(specifier);
+
+const resolveChalk = (candidate: unknown): ChalkInstance => {
+  if (typeof candidate === 'function') {
+    return candidate as ChalkInstance;
+  }
+
+  // Jest/@swc interop: default export is re-wrapped as { default, ... }
+  const nestedDefault =
+    candidate && typeof candidate === 'object' && 'default' in candidate
+      ? (candidate as { default: unknown }).default
+      : undefined;
+
+  if (typeof nestedDefault === 'function') {
+    return nestedDefault as ChalkInstance;
+  }
+
+  throw new TypeError('Failed to load chalk');
+};
+
+export const loadChalk = async (): Promise<ChalkInstance> => {
+  if (chalkInstance) {
+    return chalkInstance;
+  }
+
+  const mod = await importEsm('chalk');
+  chalkInstance = resolveChalk(mod.default);
+
+  return chalkInstance;
+};
+
+export const getChalk = (): ChalkInstance => {
+  if (!chalkInstance) {
+    throw new Error('chalk has not been loaded; call loadChalk() before using getChalk()');
+  }
+
+  return chalkInstance;
+};

--- a/src/cli/commands/utils/helpers.ts
+++ b/src/cli/commands/utils/helpers.ts
@@ -1,6 +1,7 @@
-import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+
+import { getChalk } from './chalk-loader';
 
 import type { CLIContext, CommonCLIOptions } from '../../../types';
 
@@ -11,7 +12,7 @@ import type { CLIContext, CommonCLIOptions } from '../../../types';
 export async function formatBoxedErrorStack(stack: string): Promise<string> {
   const { default: boxen } = await import('boxen');
 
-  return chalk.red(
+  return getChalk().red(
     boxen(stack, {
       padding: 1,
       align: 'left',
@@ -97,17 +98,17 @@ export const logInstructions = (
   const exportInstruction = language === 'js' ? 'module.exports =' : 'export default';
 
   return `
-You can now enable your plugin by adding the following in ${chalk.yellow(
+You can now enable your plugin by adding the following in ${getChalk().yellow(
     `./config/plugins.${language}`
   )}
 ${separator}
 ${exportInstruction} {
-  ${chalk.gray('// ...')}
-  ${chalk.green(`'${pluginName}'`)}: {
-    enabled: ${chalk.yellow(true)},
-    resolve: '${chalk.yellow(pluginPath)}'
+  ${getChalk().gray('// ...')}
+  ${getChalk().green(`'${pluginName}'`)}: {
+    enabled: ${getChalk().yellow(true)},
+    resolve: '${getChalk().yellow(pluginPath)}'
   },
-  ${chalk.gray('// ...')}
+  ${getChalk().gray('// ...')}
 }
 ${separator}
 `;

--- a/src/cli/commands/utils/logger.ts
+++ b/src/cli/commands/utils/logger.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { getChalk } from './chalk-loader';
 
 export interface LoggerOptions {
   silent?: boolean;
@@ -44,7 +44,7 @@ const createLogger = (options: LoggerOptions = {}): Logger => {
       }
 
       console.log(
-        chalk.cyan(`[DEBUG]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
+        getChalk().cyan(`[DEBUG]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
         ...args
       );
     },
@@ -55,7 +55,7 @@ const createLogger = (options: LoggerOptions = {}): Logger => {
       }
 
       console.info(
-        chalk.blue(`[INFO]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
+        getChalk().blue(`[INFO]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
         ...args
       );
     },
@@ -65,7 +65,10 @@ const createLogger = (options: LoggerOptions = {}): Logger => {
         return;
       }
 
-      console.info(chalk.blue(`${timestamp ? `\t[${new Date().toISOString()}]` : ''}`), ...args);
+      console.info(
+        getChalk().blue(`${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
+        ...args
+      );
     },
 
     warn(...args) {
@@ -76,7 +79,7 @@ const createLogger = (options: LoggerOptions = {}): Logger => {
       }
 
       console.warn(
-        chalk.yellow(`[WARN]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
+        getChalk().yellow(`[WARN]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
         ...args
       );
     },
@@ -89,7 +92,7 @@ const createLogger = (options: LoggerOptions = {}): Logger => {
       }
 
       console.error(
-        chalk.red(`[ERROR]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
+        getChalk().red(`[ERROR]${timestamp ? `\t[${new Date().toISOString()}]` : ''}`),
         ...args
       );
     },

--- a/src/cli/commands/utils/pkg.ts
+++ b/src/cli/commands/utils/pkg.ts
@@ -1,8 +1,9 @@
-import chalk from 'chalk';
 import fs from 'fs/promises';
 import os from 'os';
 import pkgUp from 'pkg-up';
 import * as yup from 'yup';
+
+import { getChalk } from './chalk-loader';
 
 import type { Logger } from './logger';
 
@@ -101,7 +102,7 @@ const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
         case 'required':
           if (err.path) {
             throw new Error(
-              `'${err.path}' in 'package.json' is required as type '${chalk.magenta(
+              `'${err.path}' in 'package.json' is required as type '${getChalk().magenta(
                 getReachableSchemaType(packageJsonSchema, err.path)
               )}'`
             );
@@ -114,9 +115,9 @@ const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
         case 'noUnknown':
           if (err.path && err.params && 'unknown' in err.params) {
             throw new Error(
-              `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
+              `'${err.path}' in 'package.json' contains the unknown key ${getChalk().magenta(
                 err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
+              )}, for compatability only the following keys are allowed: ${getChalk().magenta(
                 "['types', 'source', 'import', 'require', 'default']"
               )}`
             );
@@ -125,9 +126,9 @@ const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
         default:
           if (err.path && err.params && 'type' in err.params && 'value' in err.params) {
             throw new Error(
-              `'${err.path}' in 'package.json' must be of type '${chalk.magenta(
+              `'${err.path}' in 'package.json' must be of type '${getChalk().magenta(
                 err.params.type
-              )}' (recieved '${chalk.magenta(typeof err.params.value)}')`
+              )}' (recieved '${getChalk().magenta(typeof err.params.value)}')`
             );
           }
       }

--- a/src/cli/commands/utils/validation/file-checker.ts
+++ b/src/cli/commands/utils/validation/file-checker.ts
@@ -1,10 +1,11 @@
 /**
  * Verifies that all files referenced in package.json exports actually exist.
  */
-import chalk from 'chalk';
 import fs from 'fs/promises';
 import os from 'os';
 import { resolve } from 'path';
+
+import { getChalk } from '../chalk-loader';
 
 import type { Export } from './types';
 
@@ -105,7 +106,7 @@ export const checkExportFiles = async (
     throw new Error(
       [
         'Missing files for exports:',
-        ...missingExports.map((str) => `    ${chalk.blue(str)} -> ${resolve(cwd, str)}`),
+        ...missingExports.map((str) => `    ${getChalk().blue(str)} -> ${resolve(cwd, str)}`),
       ].join(os.EOL)
     );
   }

--- a/src/cli/commands/utils/validation/pkg-loader.ts
+++ b/src/cli/commands/utils/validation/pkg-loader.ts
@@ -4,11 +4,12 @@
  * Finds the nearest package.json, validates its structure using yup schema,
  * and extracts Strapi plugin export configuration.
  */
-import chalk from 'chalk';
 import fs from 'fs/promises';
 import os from 'os';
 import pkgUp from 'pkg-up';
 import * as yup from 'yup';
+
+import { getChalk } from '../chalk-loader';
 
 import type { Export } from './types';
 
@@ -193,7 +194,7 @@ export const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson
         case 'required':
           if (err.path) {
             throw new Error(
-              `'${err.path}' in 'package.json' is required as type '${chalk.magenta(
+              `'${err.path}' in 'package.json' is required as type '${getChalk().magenta(
                 getReachableSchemaType(packageJsonSchema, err.path)
               )}'`
             );
@@ -202,9 +203,9 @@ export const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson
         case 'matches':
           if (err.params && err.path && 'value' in err.params && 'regex' in err.params) {
             throw new Error(
-              `'${err.path}' in 'package.json' must be of type '${chalk.magenta(
+              `'${err.path}' in 'package.json' must be of type '${getChalk().magenta(
                 err.params.regex
-              )}' (recieved the value '${chalk.magenta(err.params.value)}')`
+              )}' (recieved the value '${getChalk().magenta(err.params.value)}')`
             );
           }
           break;
@@ -215,9 +216,9 @@ export const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson
         case 'noUnknown':
           if (err.path && err.params && 'unknown' in err.params) {
             throw new Error(
-              `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
+              `'${err.path}' in 'package.json' contains the unknown key ${getChalk().magenta(
                 err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
+              )}, for compatability only the following keys are allowed: ${getChalk().magenta(
                 "['types', 'source', 'import', 'require', 'default']"
               )}`
             );
@@ -226,9 +227,9 @@ export const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson
         default:
           if (err.path && err.params && 'type' in err.params && 'value' in err.params) {
             throw new Error(
-              `'${err.path}' in 'package.json' must be of type '${chalk.magenta(
+              `'${err.path}' in 'package.json' must be of type '${getChalk().magenta(
                 err.params.type
-              )}' (recieved '${chalk.magenta(typeof err.params.value)}')`
+              )}' (recieved '${getChalk().magenta(typeof err.params.value)}')`
             );
           }
       }

--- a/src/cli/commands/utils/validation/verify.ts
+++ b/src/cli/commands/utils/validation/verify.ts
@@ -24,7 +24,10 @@ export interface VerifyOptions {
  * Main verify function that validates package.json and export files
  */
 export const verify = async ({ cwd, logger }: VerifyOptions) => {
+  const { loadChalk } = await import('../chalk-loader');
   const { loadOra } = await import('../ora-loader');
+
+  await loadChalk();
   const ora = await loadOra();
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import { Command } from 'commander';
 
 import { commands as strapiCommands } from './cli/commands';
+import { loadChalk } from './cli/commands/utils/chalk-loader';
 import { createLogger } from './cli/commands/utils/logger';
 import { loadTsConfig } from './cli/commands/utils/tsconfig';
 
 import type { CLIContext } from './types';
 
 const createCLI = async (argv: string[], command = new Command()) => {
+  await loadChalk();
+
   // Initial program setup
   command.storeOptionsAsProperties(false).allowUnknownOption(true);
 


### PR DESCRIPTION
## Summary
- Bumps chalk 4.1.2 → 5.6.2 (supersedes Dependabot #160)
- Adds `chalk-loader.ts` with cached `loadChalk()` / sync `getChalk()` — same pattern as `ora-loader`
- Preloads chalk from `createCLI`, `build`, and `verify` entrypoints so the CJS `strapi-plugin` bin works with ESM-only chalk 5

## Context
Chalk 5 is ESM-only. The published bin uses `require('../dist/cli')`, so static `import chalk from 'chalk'` breaks at runtime (`chalk.cyan is not a function`). Dynamic import fixes this without changing the public API for plugin authors.

## Test plan
- [x] `pnpm check` passes locally (lint, types, 32 unit tests)
- [ ] CI green on Node 22/24/26