### PR TITLE
chore: remove pkg-up dependency

### DIFF
--- a/.changeset/forty-rats-marry.md
+++ b/.changeset/forty-rats-marry.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore: remove pkg-up dependency

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "nodemon": "^3.1.14",
     "ora": "9.4.0",
     "outdent": "0.8.0",
-    "pkg-up": "3.1.0",
     "prettier": "3.8.3",
     "prompts": "^2.4.2",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       outdent:
         specifier: 0.8.0
         version: 0.8.0
-      pkg-up:
-        specifier: 3.1.0
-        version: 3.1.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -2521,10 +2518,6 @@ packages:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
-  find-up@3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
-    engines: {node: '>=6'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3255,10 +3248,6 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
-  locate-path@3.0.0:
-    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
-    engines: {node: '>=6'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3509,10 +3498,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-locate@3.0.0:
-    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
-    engines: {node: '>=6'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -3556,10 +3541,6 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-
-  path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3624,10 +3605,6 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
-
-  pkg-up@3.1.0:
-    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
-    engines: {node: '>=8'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7162,10 +7139,6 @@ snapshots:
 
   find-up-simple@1.0.1: {}
 
-  find-up@3.0.0:
-    dependencies:
-      locate-path: 3.0.0
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -8090,11 +8063,6 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
-  locate-path@3.0.0:
-    dependencies:
-      p-locate: 3.0.0
-      path-exists: 3.0.0
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -8352,10 +8320,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-locate@3.0.0:
-    dependencies:
-      p-limit: 2.3.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -8397,8 +8361,6 @@ snapshots:
       parse-path: 7.1.0
 
   path-browserify@1.0.1: {}
-
-  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -8446,10 +8408,6 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
-
-  pkg-up@3.1.0:
-    dependencies:
-      find-up: 3.0.0
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/cli/commands/utils/find-package-json.ts
+++ b/src/cli/commands/utils/find-package-json.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Find the closest package.json file by walking up from `cwd`.
+ */
+const findPackageJson = async (cwd: string): Promise<string | undefined> => {
+  let current = path.resolve(cwd);
+  const { root } = path.parse(current);
+
+  while (current !== root) {
+    const candidate = path.join(current, 'package.json');
+
+    try {
+      await fs.access(candidate);
+
+      return candidate;
+    } catch {
+      // Continue searching in the parent directory.
+    }
+
+    current = path.dirname(current);
+  }
+
+  const rootCandidate = path.join(root, 'package.json');
+
+  try {
+    await fs.access(rootCandidate);
+
+    return rootCandidate;
+  } catch {
+    return undefined;
+  }
+};
+
+export { findPackageJson };

--- a/src/cli/commands/utils/pkg.ts
+++ b/src/cli/commands/utils/pkg.ts
@@ -1,8 +1,9 @@
 import chalk from 'chalk';
 import fs from 'fs/promises';
 import os from 'os';
-import pkgUp from 'pkg-up';
 import * as yup from 'yup';
+
+import { findPackageJson } from './find-package-json';
 
 import type { Logger } from './logger';
 
@@ -64,7 +65,7 @@ const packageJsonSchema = yup.object({
  * the process will throw with an appropriate error message.
  */
 const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promise<object> => {
-  const pkgPath = await pkgUp({ cwd });
+  const pkgPath = await findPackageJson(cwd);
 
   if (!pkgPath) {
     throw new Error('Could not find a package.json in the current directory');

--- a/src/cli/commands/utils/validation/pkg-loader.ts
+++ b/src/cli/commands/utils/validation/pkg-loader.ts
@@ -7,8 +7,9 @@
 import chalk from 'chalk';
 import fs from 'fs/promises';
 import os from 'os';
-import pkgUp from 'pkg-up';
 import * as yup from 'yup';
+
+import { findPackageJson } from '../find-package-json';
 
 import type { Export } from './types';
 
@@ -161,7 +162,7 @@ export const loadPkg = async ({
   cwd: string;
   logger: Logger;
 }): Promise<object> => {
-  const pkgPath = await pkgUp({ cwd });
+  const pkgPath = await findPackageJson(cwd);
 
   if (!pkgPath) {
     throw new Error('Could not find a package.json in the current directory');


### PR DESCRIPTION
## Summary
- Remove the deprecated `pkg-up` dependency and inline the same package.json lookup in a small `findPackageJson` helper
- Update `loadPkg` call sites in `pkg.ts` and `pkg-loader.ts` to use the helper

This supersedes #159. Upgrading `pkg-up` to v5 is not worthwhile: the package is deprecated in favour of `package-up`, v5 is ESM-only, and the CLI only needed its trivial "walk up to find package.json" behaviour.

## User impact
No breaking change for plugin authors. This is an internal dependency removal with identical runtime behaviour.

## Related issue(s)/PR(s)
Fixes CMS-1100

## Test plan
- [x] `pnpm check` passes locally (lint, typecheck, unit tests)
- [x] CI green on Node 22/24/26