### PR TITLE
chore: use isBuiltin from node:module

### DIFF
--- a/.changeset/yummy-readers-burn.md
+++ b/.changeset/yummy-readers-burn.md
@@ -1,0 +1,5 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore: use isBuiltin from node:module

--- a/src/cli/commands/utils/build/vite-config.ts
+++ b/src/cli/commands/utils/build/vite-config.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { builtinModules } from 'node:module';
+import { isBuiltin as isNodeBuiltin } from 'node:module';
 import path from 'node:path';
 
 import type { BundleConfig } from './index';
@@ -52,19 +52,12 @@ function externalizeDepsPlugin(externals: string[]): Plugin {
         return { id: source, external: true };
       }
       // Also externalize node built-ins
-      if (source.startsWith('node:') || isNodeBuiltin(source)) {
+      if (isNodeBuiltin(source)) {
         return { id: source, external: true };
       }
       return null;
     },
   };
-}
-
-/**
- * Check if a module is a Node.js built-in.
- */
-function isNodeBuiltin(id: string): boolean {
-  return builtinModules.includes(id);
 }
 
 /**
@@ -154,7 +147,7 @@ export async function createViteConfig(options: ViteConfigOptions): Promise<Inli
             return true;
           }
           // Externalize node built-ins
-          if (id.startsWith('node:') || isNodeBuiltin(id)) {
+          if (isNodeBuiltin(id)) {
             return true;
           }
           return false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { builtinModules } from 'node:module';
+import { isBuiltin as isNodeBuiltin } from 'node:module';
 import { defineConfig } from 'vite';
 
 type PackageJsonLike = {
@@ -11,7 +11,6 @@ const pkg = JSON.parse(
 ) as PackageJsonLike;
 
 const externals = Object.keys(pkg.dependencies ?? {});
-const builtins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
 
 export default defineConfig({
   build: {
@@ -27,7 +26,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external(id) {
-        if (builtins.has(id)) {
+        if (isNodeBuiltin(id)) {
           return true;
         }
 


### PR DESCRIPTION
### What does it do?

Replaces the manual `builtinModules`-based Node.js built-in detection with `isBuiltin` from `node:module` in both `vite.config.ts` and `src/cli/commands/utils/build/vite-config.ts`.

`isBuiltin` returns `true` for both bare (`fs`) and `node:`-prefixed (`node:fs`) specifiers, so the explicit `startsWith('node:')` checks and the manually-built `Set` of prefixed names are no longer needed. Imported as `isNodeBuiltin` for readability.

### Why is it needed?

Simpler, less error-prone built-in detection using the platform-provided API instead of hand-rolled logic.

### How to test it?

Run the build (`pnpm build`) and confirm Node built-ins remain externalized in the output bundles.

### Related issue(s)/PR(s)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)