### PR TITLE
chore: ignore AI tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,22 @@ package-lock.json
 ############################
 
 __tmp__/
+
+############################
+# AI tools
+############################
+
+# cms-brain (symlinked skills/commands/context)
+.brain
+.brain.*
+
+# Claude
+CLAUDE.local.md
+.claude/
+
+# Cursor
+.cursor/
+!.cursor/worktrees.json
+
+# Codex
+.agents/


### PR DESCRIPTION
## Summary

- Adds an `AI tools` section to `.gitignore`, aligned with `strapi/strapi`, so AI tooling artifacts are never accidentally committed.
- Covers the paths the `cms-brain` CLI symlinks into a checkout — `.brain` (skills/commands/context), plus the per-tool link dirs `.claude/`, `.cursor/`, `.agents/` — as well as `CLAUDE.local.md`.

```gitignore
############################
# AI tools
############################

# cms-brain (symlinked skills/commands/context)
.brain
.brain.*

# Claude
CLAUDE.local.md
.claude/

# Cursor
.cursor/
!.cursor/worktrees.json

# Codex
.agents/
```

No previously tracked files match these paths, so nothing is untracked by this change.

## Test plan

- [ ] `git check-ignore .brain .cursor/skills .claude/skills .agents/skills` → all ignored
- [ ] `git status` is unaffected for existing tracked files