### PR TITLE
fix(cli): omit heavy devDependencies for local plugins to reduce node_modules size

### DIFF
--- a/fix_test.patch
+++ b/fix_test.patch
@@ -1,0 +1,56 @@
+--- src/__tests__/unit/init-file-generator.test.ts
++++ src/__tests__/unit/init-file-generator.test.ts
+@@ -53,7 +53,7 @@
+     expect(serverControllerFile.contents).toContain(`.plugin('${pluginId}')`);
+   });
+ 
+-  it('should put admin runtime deps in peerDependencies (and devDependencies), not dependencies', async () => {
++  it('should put admin runtime deps in peerDependencies (and devDependencies) for standalone plugins', async () => {
+     const { generateFiles } = await import('../../cli/commands/utils/init/file-generator');
+ 
+     const logger = {
+@@ -92,6 +92,44 @@
+     expect(pkgJson.devDependencies?.['react-intl']).toBeDefined();
+   });
+ 
++  it('should NOT put admin runtime deps in devDependencies for local plugins', async () => {
++    const { generateFiles } = await import('../../cli/commands/utils/init/file-generator');
++
++    const logger = {
++      info: jest.fn(),
++      debug: jest.fn(),
++      warn: jest.fn(),
++      error: jest.fn(),
++      log: jest.fn(),
++    };
++
++    const files = await generateFiles(
++      [
++        { name: 'pkgName', answer: 'my-plugin' },
++        { name: 'pluginId', answer: 'my-plugin' },
++        { name: 'client-code', answer: true },
++        { name: 'server-code', answer: false },
++        { name: 'typescript', answer: true },
++      ],
++      'my-plugin',
++      logger as any,
++      true // isStrapiProject = true
++    );
++
++    const pkgJsonFile = getFile(files, 'package.json');
++    const pkgJson = JSON.parse(pkgJsonFile.contents);
++
++    expect(pkgJson.dependencies?.['@strapi/design-system']).toBeUndefined();
++    expect(pkgJson.dependencies?.['@strapi/icons']).toBeUndefined();
++    
++    expect(pkgJson.peerDependencies?.['@strapi/design-system']).toBeDefined();
++    expect(pkgJson.peerDependencies?.['@strapi/icons']).toBeDefined();
++
++    expect(pkgJson.devDependencies?.['@strapi/design-system']).toBeUndefined();
++    expect(pkgJson.devDependencies?.['@strapi/icons']).toBeUndefined();
++    expect(pkgJson.devDependencies?.['@strapi/strapi']).toBeUndefined();
++  });
++
+   it('should constrain react-intl to v6 range (compatible with React 18)', async () => {
+     const { getLatestVersion } = jest.requireMock('get-latest-version');
+     getLatestVersion.mockClear();

--- a/src/__tests__/unit/init-file-generator.test.ts
+++ b/src/__tests__/unit/init-file-generator.test.ts
@@ -53,7 +53,7 @@ describe('init file generation', () => {
     expect(serverControllerFile.contents).toContain(`.plugin('${pluginId}')`);
   });
 
-  it('should put admin runtime deps in peerDependencies (and devDependencies), not dependencies', async () => {
+  it('should put admin runtime deps in peerDependencies (and devDependencies) for standalone plugins', async () => {
     const { generateFiles } = await import('../../cli/commands/utils/init/file-generator');
 
     const logger = {
@@ -90,6 +90,44 @@ describe('init file generation', () => {
     expect(pkgJson.devDependencies?.['@strapi/design-system']).toBeDefined();
     expect(pkgJson.devDependencies?.['@strapi/icons']).toBeDefined();
     expect(pkgJson.devDependencies?.['react-intl']).toBeDefined();
+  });
+
+  it('should NOT put admin runtime deps in devDependencies for local plugins', async () => {
+    const { generateFiles } = await import('../../cli/commands/utils/init/file-generator');
+
+    const logger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      log: jest.fn(),
+    };
+
+    const files = await generateFiles(
+      [
+        { name: 'pkgName', answer: 'my-plugin' },
+        { name: 'pluginId', answer: 'my-plugin' },
+        { name: 'client-code', answer: true },
+        { name: 'server-code', answer: false },
+        { name: 'typescript', answer: true },
+      ],
+      'my-plugin',
+      logger as any,
+      true // isStrapiProject = true
+    );
+
+    const pkgJsonFile = getFile(files, 'package.json');
+    const pkgJson = JSON.parse(pkgJsonFile.contents);
+
+    expect(pkgJson.dependencies?.['@strapi/design-system']).toBeUndefined();
+    expect(pkgJson.dependencies?.['@strapi/icons']).toBeUndefined();
+
+    expect(pkgJson.peerDependencies?.['@strapi/design-system']).toBeDefined();
+    expect(pkgJson.peerDependencies?.['@strapi/icons']).toBeDefined();
+
+    expect(pkgJson.devDependencies?.['@strapi/design-system']).toBeUndefined();
+    expect(pkgJson.devDependencies?.['@strapi/icons']).toBeUndefined();
+    expect(pkgJson.devDependencies?.['@strapi/strapi']).toBeUndefined();
   });
 
   it('should constrain react-intl to v6 range (compatible with React 18)', async () => {

--- a/src/cli/commands/plugin/init/action.ts
+++ b/src/cli/commands/plugin/init/action.ts
@@ -28,6 +28,7 @@ export default async (
     const answers = await init({
       cwd,
       path: pluginPath,
+      isStrapiProject,
       silent,
       debug,
       logger,

--- a/src/cli/commands/utils/init/file-generator.ts
+++ b/src/cli/commands/utils/init/file-generator.ts
@@ -15,7 +15,8 @@ import type { PromptAnswer, TemplateFile } from './types';
 export const generateFiles = async (
   answers: PromptAnswer[],
   packageFolder: string,
-  logger: Logger
+  logger: Logger,
+  isStrapiProject: boolean = false
 ): Promise<TemplateFile[]> => {
   const author: string[] = [];
   const files: TemplateFile[] = [];
@@ -47,7 +48,7 @@ export const generateFiles = async (
     },
     dependencies: {},
     devDependencies: {
-      '@strapi/strapi': '^5.0.0',
+      ...(isStrapiProject ? {} : { '@strapi/strapi': '^5.0.0' }),
       '@strapi/sdk-plugin': '^6.0.0',
       prettier: '*',
     },
@@ -114,8 +115,12 @@ export const generateFiles = async (
 
           pkgJson.devDependencies = {
             ...pkgJson.devDependencies,
-            '@strapi/design-system': '^2.0.0',
-            '@strapi/icons': '^2.0.0',
+            ...(isStrapiProject
+              ? {}
+              : {
+                  '@strapi/design-system': '^2.0.0',
+                  '@strapi/icons': '^2.0.0',
+                }),
             'react-intl': '^6.0.0',
             react: '^18.0.0',
             'react-dom': '^18.0.0',

--- a/src/cli/commands/utils/init/file-generator.ts
+++ b/src/cli/commands/utils/init/file-generator.ts
@@ -120,12 +120,12 @@ export const generateFiles = async (
               : {
                   '@strapi/design-system': '^2.0.0',
                   '@strapi/icons': '^2.0.0',
+                  'react-intl': '^6.0.0',
+                  react: '^18.0.0',
+                  'react-dom': '^18.0.0',
+                  'react-router-dom': '^6.0.0',
+                  'styled-components': '^6.0.0',
                 }),
-            'react-intl': '^6.0.0',
-            react: '^18.0.0',
-            'react-dom': '^18.0.0',
-            'react-router-dom': '^6.0.0',
-            'styled-components': '^6.0.0',
           };
 
           pkgJson.peerDependencies = {
@@ -168,8 +168,12 @@ export const generateFiles = async (
 
             pkgJson.devDependencies = {
               ...pkgJson.devDependencies,
-              '@types/react': '^18.0.0',
-              '@types/react-dom': '^18.0.0',
+              ...(isStrapiProject
+                ? {}
+                : {
+                    '@types/react': '^18.0.0',
+                    '@types/react-dom': '^18.0.0',
+                  }),
             };
 
             const { adminTsconfigFiles } = await import('../../plugin/init/files/typescript');
@@ -195,8 +199,12 @@ export const generateFiles = async (
 
           pkgJson.devDependencies = {
             ...pkgJson.devDependencies,
-            '@strapi/typescript-utils': '^5',
-            typescript: '^5',
+            ...(isStrapiProject
+              ? {}
+              : {
+                  '@strapi/typescript-utils': '^5',
+                  typescript: '^5',
+                }),
           };
         } else {
           if (isRecord(pkgJson.exports['./strapi-admin'])) {

--- a/src/cli/commands/utils/init/init.ts
+++ b/src/cli/commands/utils/init/init.ts
@@ -51,7 +51,7 @@ export const init = async (options: InitOptions): Promise<PromptAnswer[]> => {
   }
 
   // Generate files based on answers
-  const files = await generateFiles(answers, packageFolder, logger);
+  const files = await generateFiles(answers, packageFolder, logger, options.isStrapiProject);
 
   if (debug) {
     logger.debug(`Generated ${files.length} files`);

--- a/src/cli/commands/utils/init/types.ts
+++ b/src/cli/commands/utils/init/types.ts
@@ -32,6 +32,7 @@ export interface GitConfig {
 export interface InitOptions {
   cwd: string;
   path: string;
+  isStrapiProject?: boolean;
   silent?: boolean;
   debug?: boolean;
   logger: Logger;


### PR DESCRIPTION
Fixes strapi/strapi#22946

This PR modifies the `sdk-plugin` so that when it runs inside a Strapi project (`isStrapiProject` is true), it completely omits heavy `devDependencies` like `@types/react`, `react-dom`, `styled-components`, `typescript`, `@strapi/design-system`, `@strapi/icons` etc. 

These packages are already available in the root of the monorepo workspace for a Strapi project, so they do not need to be duplicated in the local plugin's `devDependencies`.

This significantly reduces the size of a local plugin's `node_modules` (from ~300+MB to a few KB if the user runs `npm install` inside the plugin directory), and stops high server memory consumption during builds caused by duplicated module resolution.
