### PR TITLE
chore: backfill changesets for prettier, ora, and execa

### DIFF
--- a/.changeset/execa-10.md
+++ b/.changeset/execa-10.md
@@ -1,0 +1,7 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore(deps): bump execa from ^9.6.1 to ^10.0.0
+
+Backfill for the major dependency bump in #205 (lockfile-only follow-up #215 stayed within ^10).

--- a/.changeset/ora-9-4-1.md
+++ b/.changeset/ora-9-4-1.md
@@ -1,0 +1,7 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore(deps): bump ora from 9.4.0 to 9.4.1
+
+Backfill for Dependabot bump #191 that landed without a changeset.

--- a/.changeset/prettier-3-9-6.md
+++ b/.changeset/prettier-3-9-6.md
@@ -1,0 +1,7 @@
+---
+"@strapi/sdk-plugin": patch
+---
+
+chore(deps): bump prettier from 3.8.3 to 3.9.6
+
+Backfill for Dependabot bumps that landed without a changeset (#182, #196, #200, #210).


### PR DESCRIPTION
### What does it do?

Backfill missing patch changesets for user-facing dependency bumps since v6.1.1 that never got a changeset: prettier 3.8.3→3.9.6, ora 9.4.0→9.4.1, execa ^9→^10.

No runtime code changes — publish bookkeeping only so the next version PR includes these.

### Why is it needed?

These Dependabot bumps landed on main without changesets, so they would not appear in the next release version PR.

### How to test it?

- [ ] Changeset files parse (`pnpm changeset status` or equivalent)
- [ ] Version PR after merge lists these three patches

### Related issue(s)/PR(s)

- prettier: #182, #196, #200, #210
- ora: #191
- execa: #205 (#215 was lock-only within ^10)